### PR TITLE
Fix ProjectAnalyzer function range detection

### DIFF
--- a/error_agent/tools.py
+++ b/error_agent/tools.py
@@ -92,14 +92,19 @@ class ProjectAnalyzer:
                 
                 # Find the function in the module
                 for name, obj in inspect.getmembers(module):
-                    if (inspect.isfunction(obj) and 
-                        obj.__code__.co_filename == frame.filename and
-                        obj.__code__.co_firstlineno <= frame.lineno <= 
-                        obj.__code__.co_firstlineno + obj.__code__.co_code.co_size):
-                        return {
-                            "name": name,
-                            "context": inspect.getsource(obj)
-                        }
+                    if inspect.isfunction(obj) and obj.__code__.co_filename == frame.filename:
+                        try:
+                            source_lines, start_line = inspect.getsourcelines(obj)
+                            end_line = start_line + len(source_lines) - 1
+                        except (OSError, TypeError):
+                            source_lines, start_line = [], obj.__code__.co_firstlineno
+                            end_line = obj.__code__.co_firstlineno
+
+                        if start_line <= frame.lineno <= end_line:
+                            return {
+                                "name": name,
+                                "context": "".join(source_lines) if source_lines else inspect.getsource(obj)
+                            }
         except Exception:
             pass
             


### PR DESCRIPTION
## Summary
- fix the logic used by `_get_function_info` to determine if a frame is inside a function

## Testing
- `python -m py_compile error_agent/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684584cf9db8832c9b0d6ebce7befae7